### PR TITLE
Handle failures when reading stored best times

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -7,7 +7,13 @@ export class GameState {
         this.startTime = 0;
         this.timer = null;
         this.isGameActive = false;
-        this.bestTimes = JSON.parse(localStorage.getItem('puzzleBestTimes') || '{}');
+        const storedBestTimes = localStorage.getItem('puzzleBestTimes');
+        try {
+            this.bestTimes = storedBestTimes ? JSON.parse(storedBestTimes) : {};
+        } catch (error) {
+            console.warn('Failed to parse puzzle best times; using defaults.', error);
+            this.bestTimes = {};
+        }
         this.isSolving = false;
         this.solveMoves = [];
         this.currentSolveStep = 0;


### PR DESCRIPTION
## Summary
- wrap the stored best-times JSON parsing in a try/catch
- log a warning and fall back to defaults when localStorage data is invalid

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c90776b060832f822b6093495ccb72