### PR TITLE
Handle invalid leaderboard JSON

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -69,7 +69,19 @@ export class UIManager {
         this.image = null;
         this.originalImage = null;
         this.tileSize = 0;
-        this.leaderboard = JSON.parse(localStorage.getItem('puzzleLeaderboard') || '[]');
+
+        // Load leaderboard data with error handling in case stored JSON is invalid
+        this.leaderboard = [];
+        const storedLeaderboard = localStorage.getItem('puzzleLeaderboard');
+        if (storedLeaderboard) {
+            try {
+                this.leaderboard = JSON.parse(storedLeaderboard);
+            } catch (error) {
+                console.warn('Failed to parse stored leaderboard data. Resetting to empty leaderboard.', error);
+                this.leaderboard = [];
+                localStorage.setItem('puzzleLeaderboard', '[]');
+            }
+        }
         this.playerName = localStorage.getItem('puzzlePlayerName') || '';
         this.isSelectingFile = false;
         this.shuffleModalTimer = null;


### PR DESCRIPTION
## Summary
- wrap leaderboard parsing in initializeState with error handling
- fall back to an empty leaderboard and log a warning when stored data is invalid

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c907a6e580832f8f0179f73fb3b9c1