### PR TITLE
Add record save callback wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ src/
 The original monolithic `script.js` has been refactored into three modules:
 
 - **GameState**: Handles puzzle logic, moves, timing, and game rules
-- **UIManager**: Manages DOM elements, canvas drawing, and user interactions
+- **UIManager**: Manages DOM elements, canvas drawing, and user interactions. Exposes callbacks like `onRecordSave` so the orchestrator can persist leaderboard data.
 - **SlidePuzzle**: Orchestrates the game flow and connects the other modules
 
 All functionality from the original version is preserved while providing better code organization and maintainability.

--- a/src/ui.js
+++ b/src/ui.js
@@ -109,6 +109,7 @@ export class UIManager {
         this.onDifficultyChange = null;
         this.onRetry = null;
         this.onNewImage = null;
+        this.onRecordSave = null; // Fired when the player confirms saving a leaderboard entry
     }
 
     setupEventListeners() {
@@ -985,9 +986,10 @@ export class UIManager {
         // Save player name for future use
         this.playerName = name;
         localStorage.setItem('puzzlePlayerName', name);
-        
+
         this.playerNameModal.classList.add('hidden');
-        
+
+        // Allow the orchestrator to persist the leaderboard record when available
         if (this.onRecordSave) {
             this.onRecordSave(name);
         }


### PR DESCRIPTION
## Summary
- initialize the UIManager `onRecordSave` callback during state setup
- document how the callback is used when persisting leaderboard entries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c907bada74832f91453581fad64167