### PR TITLE
Remove inline handlers and drop puzzleGame global

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,8 +64,8 @@
                         <span>Moves: <strong id="finalMoves">0</strong></span>
                     </div>
                     <div class="win-actions">
-                        <button id="retryBtn" class="btn btn-primary" onclick="window.puzzleGame && window.puzzleGame.retryPuzzle()">🔄 Retry Puzzle</button>
-                        <button id="newPuzzleBtn" class="btn btn-secondary" onclick="window.puzzleGame && window.puzzleGame.loadNewImage()">📁 New Image</button>
+                        <button id="retryBtn" class="btn btn-primary">🔄 Retry Puzzle</button>
+                        <button id="newPuzzleBtn" class="btn btn-secondary">📁 New Image</button>
                     </div>
                 </div>
             </div>

--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,7 @@ class SlidePuzzle {
         this.ui.onNextMove = () => this.showNextMove();
         this.ui.onDifficultyChange = (difficulty) => this.onDifficultyChange(difficulty);
         this.ui.onRetry = () => this.retryPuzzle();
-        this.ui.onNewImage = () => this.ui.loadNewImage();
+        this.ui.onNewImage = () => this.handleNewImageRequest();
         this.ui.onRecordSave = (name) => this.saveRecord(name);
     }
 
@@ -35,6 +35,25 @@ class SlidePuzzle {
         const gridSize = parseInt(this.ui.difficultySelect.value);
         this.game.setupGame(gridSize);
         this.ui.setupPuzzle(gridSize, image);
+    }
+
+    handleNewImageRequest() {
+        this.ui.hideWinMessage();
+        this.ui.clearShuffleTimer();
+        this.ui.setDifficultyDisabled(false);
+
+        if (this.timerInterval) {
+            clearInterval(this.timerInterval);
+            this.timerInterval = null;
+        }
+
+        if (this.game.timer) {
+            clearInterval(this.game.timer);
+            this.game.timer = null;
+        }
+
+        this.game.isGameActive = false;
+        this.ui.loadNewImage();
     }
 
     startNewGame() {
@@ -328,5 +347,5 @@ class SlidePuzzle {
 // Initialize the game when the page loads
 document.addEventListener('DOMContentLoaded', () => {
     console.log('DOM loaded, creating SlidePuzzle instance');
-    window.puzzleGame = new SlidePuzzle();
+    new SlidePuzzle();
 });

--- a/src/ui.js
+++ b/src/ui.js
@@ -201,7 +201,11 @@ export class UIManager {
             this.newPuzzleBtn.addEventListener('click', (e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                this.loadNewImage();
+                if (this.onNewImage) {
+                    this.onNewImage();
+                } else {
+                    this.loadNewImage();
+                }
             });
         }
         
@@ -214,7 +218,11 @@ export class UIManager {
             } else if (e.target.id === 'newPuzzleBtn') {
                 e.preventDefault();
                 e.stopPropagation();
-                this.loadNewImage();
+                if (this.onNewImage) {
+                    this.onNewImage();
+                } else {
+                    this.loadNewImage();
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary
- remove inline onclick handlers from the win dialog buttons
- route the win dialog buttons through UIManager callbacks, adding SlidePuzzle handling for new image requests
- instantiate the game without leaking the instance onto the window object

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c907c12000832fa6f4cc2702ce1577