### PR TITLE
Remove redundant game timer interval

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -5,7 +5,6 @@ export class GameState {
         this.emptyIndex = 0;
         this.moveCount = 0;
         this.startTime = 0;
-        this.timer = null;
         this.isGameActive = false;
         this.bestTimes = JSON.parse(localStorage.getItem('puzzleBestTimes') || '{}');
         this.isSolving = false;
@@ -106,17 +105,11 @@ export class GameState {
         
         this.shufflePuzzle();
         
-        if (this.timer) clearInterval(this.timer);
-        this.timer = setInterval(() => this.updateTimer(), 1000);
     }
 
     endGame() {
         this.isGameActive = false;
-        if (this.timer) {
-            clearInterval(this.timer);
-            this.timer = null;
-        }
-        
+
         const endTime = Date.now();
         const totalTime = Math.floor((endTime - this.startTime) / 1000);
         

--- a/src/main.js
+++ b/src/main.js
@@ -56,12 +56,23 @@ class SlidePuzzle {
     }
 
     startTimerDisplay() {
-        if (this.timerInterval) clearInterval(this.timerInterval);
+        if (this.timerInterval) {
+            clearInterval(this.timerInterval);
+            this.timerInterval = null;
+        }
+
+        if (this.game.isGameActive) {
+            const elapsed = this.game.updateTimer();
+            this.ui.updateTimer(elapsed);
+        } else {
+            this.ui.updateTimer(0);
+        }
+
         this.timerInterval = setInterval(() => {
-            if (this.game.isGameActive) {
-                const elapsed = this.game.updateTimer();
-                this.ui.updateTimer(elapsed);
-            }
+            if (!this.game.isGameActive) return;
+
+            const elapsed = this.game.updateTimer();
+            this.ui.updateTimer(elapsed);
         }, 1000);
     }
 


### PR DESCRIPTION
## Summary
- remove the unused timer interval from `GameState.startGame`
- rely on the UI-driven `startTimerDisplay` loop for updating the timer display
- ensure the timer display interval is reset cleanly before reuse

## Testing
- no tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9079a6af8832fa566779e0eb940df