### PR TITLE
Ensure best move reduces distance

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "python3 -m http.server 8000",
     "dev-win": "python -m http.server 8000",
-    "start": "python3 -m http.server 8000"
+    "start": "python3 -m http.server 8000",
+    "test": "node tests/findNextBestMove.test.js"
   },
   "keywords": ["puzzle", "game", "javascript", "canvas"],
   "author": "",

--- a/src/game.js
+++ b/src/game.js
@@ -259,7 +259,7 @@ export class GameState {
         
         // Find the move that puts a tile closer to its correct position
         let bestMove = -1;
-        let bestScore = -1;
+        let bestScore = Infinity;
         
         for (const move of validMoves) {
             const tileNum = this.tiles[move];
@@ -267,12 +267,12 @@ export class GameState {
             const distance = this.getManhattanDistance(move, correctPos);
             const newDistance = this.getManhattanDistance(emptyPos, correctPos);
             
-            if (newDistance < distance && newDistance < bestScore || bestScore === -1) {
+            if (bestScore === -1 || (newDistance < distance && newDistance < bestScore)) {
                 bestScore = newDistance;
                 bestMove = move;
             }
         }
-        
+
         return bestMove !== -1 ? bestMove : (validMoves.length > 0 ? validMoves[0] : -1);
     }
 

--- a/tests/findNextBestMove.test.js
+++ b/tests/findNextBestMove.test.js
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+
+if (typeof globalThis.localStorage === 'undefined') {
+    const storage = new Map();
+    globalThis.localStorage = {
+        getItem(key) {
+            return storage.has(key) ? storage.get(key) : null;
+        },
+        setItem(key, value) {
+            storage.set(key, String(value));
+        },
+        removeItem(key) {
+            storage.delete(key);
+        },
+        clear() {
+            storage.clear();
+        }
+    };
+}
+
+const { GameState } = await import('../src/game.js');
+
+function getImprovingMoves(game) {
+    const emptyPos = game.tiles.indexOf(game.emptyIndex);
+    return game.getValidMoves(emptyPos).filter((move) => {
+        const tileNum = game.tiles[move];
+        const correctPos = tileNum;
+        const currentDistance = game.getManhattanDistance(move, correctPos);
+        const newDistance = game.getManhattanDistance(emptyPos, correctPos);
+        return newDistance < currentDistance;
+    });
+}
+
+function getDistancesForMove(game, move) {
+    const tileNum = game.tiles[move];
+    const correctPos = tileNum;
+    const emptyPos = game.tiles.indexOf(game.emptyIndex);
+    return {
+        before: game.getManhattanDistance(move, correctPos),
+        after: game.getManhattanDistance(emptyPos, correctPos)
+    };
+}
+
+const scenarios = [
+    {
+        description: 'prefers moving tile closer when adjacent tile is already solved',
+        tiles: [0, 7, 2, 3, 4, 5, 6, 8, 1],
+        expectedMove: 8
+    },
+    {
+        description: 'selects a reducing move when multiple candidates are available',
+        tiles: [0, 6, 2, 7, 8, 5, 1, 3, 4]
+    }
+];
+
+for (const { description, tiles, expectedMove } of scenarios) {
+    const game = new GameState();
+    game.setupGame(3);
+    game.tiles = tiles;
+
+    const improvingMoves = getImprovingMoves(game);
+    const chosenMove = game.findNextBestMove();
+
+    if (expectedMove !== undefined) {
+        assert.strictEqual(
+            chosenMove,
+            expectedMove,
+            `Unexpected move selected for scenario: ${description}`
+        );
+    }
+
+    if (improvingMoves.length > 0) {
+        assert(
+            improvingMoves.includes(chosenMove),
+            `Selected move should reduce distance when possible: ${description}`
+        );
+
+        const { before, after } = getDistancesForMove(game, chosenMove);
+        assert(
+            after < before,
+            `Selected move must reduce Manhattan distance: ${description}`
+        );
+    } else {
+        const emptyPos = game.tiles.indexOf(game.emptyIndex);
+        const validMoves = game.getValidMoves(emptyPos);
+        assert.strictEqual(
+            chosenMove,
+            validMoves[0] ?? -1,
+            `When no improvement exists, should fall back to first valid move: ${description}`
+        );
+    }
+}
+
+console.log('All findNextBestMove scenarios passed.');


### PR DESCRIPTION
## Summary
- require findNextBestMove to only lock in candidates that improve a tile's Manhattan distance
- add targeted scenarios proving the helper picks a distance-reducing move when one exists
- expose an npm test script for running the new checks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c907a33028832f9b91f72bea31be7a