### PR TITLE
Fix duplicate leaderboard save handling

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -506,18 +506,11 @@ export class UIManager {
     saveRecord() {
         this.leaderboardManager.saveRecord();
 
-        const name = this.playerNameInput.value.trim() || 'Anonymous';
-        
-        // Save player name for future use
-        this.playerName = name;
-        localStorage.setItem('puzzlePlayerName', name);
-
-        this.playerNameModal.classList.add('hidden');
-
-        // Allow the orchestrator to persist the leaderboard record when available
-        if (this.onRecordSave) {
-            this.onRecordSave(name);
-        }
+        // Keep the cached player name in sync for any callers using the UI
+        // facade directly. The LeaderboardManager already persists the name
+        // and notifies the orchestrator, so we simply mirror the updated
+        // value here to avoid duplicate callbacks.
+        this.playerName = this.leaderboardManager.playerName;
     }
 
     skipRecord() {


### PR DESCRIPTION
## Summary
- prevent UIManager.saveRecord from duplicating leaderboard persistence by delegating to the LeaderboardManager
- keep the cached UI player name in sync with the manager after saving

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c90e445244832f9d0786e3537f236c