### PR TITLE
Rebuild responsive cropper with pointer controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,18 @@
             <div class="shuffle-preview">
                 <canvas id="shufflePreviewCanvas" width="200" height="200"></canvas>
             </div>
-            
+
+            <div class="shuffle-settings">
+                <label for="shuffleDifficulty" class="shuffle-label">Select Puzzle Size</label>
+                <select id="shuffleDifficulty" class="difficulty-select">
+                    <option value="2">Super Easy (2×2)</option>
+                    <option value="3">Easy (3×3)</option>
+                    <option value="4">Medium (4×4)</option>
+                    <option value="5">Hard (5×5)</option>
+                    <option value="6">Expert (6×6)</option>
+                </select>
+            </div>
+
             <div class="crop-actions">
                 <button id="startShuffleBtn" class="btn btn-primary">🎲 Shuffle & Start!</button>
                 <button id="cancelShuffleBtn" class="btn btn-secondary">Not Yet</button>

--- a/src/cropping.js
+++ b/src/cropping.js
@@ -1,22 +1,23 @@
 export class CropManager {
     constructor(ui) {
         this.ui = ui;
+        this.MIN_SELECTION_PX = 80;
+
         this.state = {
-            isDragging: false,
-            isResizing: false,
-            dragHandle: null,
-            startX: 0,
-            startY: 0,
-            startCropX: 0,
-            startCropY: 0,
-            startCropWidth: 0,
-            startCropHeight: 0,
-            cropX: 50,
-            cropY: 50,
-            cropWidth: 200,
-            cropHeight: 200,
-            canvasScale: 1
+            selection: null,
+            display: { width: 0, height: 0 },
+            mode: null,
+            activeHandle: null,
+            startPointer: null,
+            startPointerNorm: null,
+            initialSelection: null,
+            activePointerId: null
         };
+
+        this.boundHandleResize = this.handleResize.bind(this);
+        this.boundPointerUp = this.onPointerUp.bind(this);
+        this.resizeFrame = null;
+        this.globalPointerListenersAttached = false;
     }
 
     handleImageUpload(event) {
@@ -52,80 +53,544 @@ export class CropManager {
         if (!this.ui.originalImage) return;
 
         this.ui.cropModal.classList.remove('hidden');
-        this.setupCropCanvas();
-        this.initializeCropSelection();
+        this.resetPointerState();
+        this.detachResizeListener();
+
+        requestAnimationFrame(() => {
+            this.layoutCropSurface({ resetSelection: true });
+            window.addEventListener('resize', this.boundHandleResize);
+        });
     }
 
-    setupCropCanvas() {
-        const maxWidth = 600;
-        const maxHeight = 400;
-        let displayWidth = this.ui.originalImage.width;
-        let displayHeight = this.ui.originalImage.height;
-
-        const scale = Math.min(maxWidth / displayWidth, maxHeight / displayHeight, 1);
-        displayWidth *= scale;
-        displayHeight *= scale;
-
-        this.ui.cropCanvas.width = displayWidth;
-        this.ui.cropCanvas.height = displayHeight;
-        this.state.canvasScale = displayWidth / this.ui.originalImage.width;
-
-        this.ui.cropCtx.clearRect(0, 0, displayWidth, displayHeight);
-        this.ui.cropCtx.drawImage(this.ui.originalImage, 0, 0, displayWidth, displayHeight);
-
-        this.ui.cropOverlay.style.width = `${displayWidth}px`;
-        this.ui.cropOverlay.style.height = `${displayHeight}px`;
-    }
-
-    initializeCropSelection() {
-        const canvasWidth = this.ui.cropCanvas.width;
-        const canvasHeight = this.ui.cropCanvas.height;
-        const isMobile = window.innerWidth <= 768;
-        const sizeRatio = isMobile ? 0.7 : 0.6;
-        const size = Math.min(canvasWidth, canvasHeight) * sizeRatio;
-
-        this.state.cropWidth = size;
-        this.state.cropHeight = size;
-        this.state.cropX = Math.max(0, (canvasWidth - size) / 2);
-        this.state.cropY = Math.max(0, (canvasHeight - size) / 2);
-
-        if (this.state.cropX + this.state.cropWidth > canvasWidth) {
-            this.state.cropX = canvasWidth - this.state.cropWidth;
-        }
-        if (this.state.cropY + this.state.cropHeight > canvasHeight) {
-            this.state.cropY = canvasHeight - this.state.cropHeight;
+    layoutCropSurface({ resetSelection = false } = {}) {
+        if (!this.ui.originalImage) {
+            return;
         }
 
-        this.updateCropSelection();
+        const display = this.calculateDisplayDimensions();
+        this.state.display = display;
+
+        const { cropCanvas, cropCtx, cropOverlay, cropContainer } = this.ui;
+        cropCanvas.width = display.width;
+        cropCanvas.height = display.height;
+        cropCanvas.style.width = `${display.width}px`;
+        cropCanvas.style.height = `${display.height}px`;
+
+        cropOverlay.style.width = `${display.width}px`;
+        cropOverlay.style.height = `${display.height}px`;
+
+        if (cropContainer) {
+            cropContainer.style.width = `${display.width}px`;
+            cropContainer.style.height = `${display.height}px`;
+        }
+
+        cropCtx.clearRect(0, 0, display.width, display.height);
+        cropCtx.drawImage(this.ui.originalImage, 0, 0, display.width, display.height);
+
+        if (resetSelection || !this.state.selection) {
+            this.state.selection = this.getDefaultSelection();
+        }
+
+        this.applySelection();
     }
 
-    updateCropSelection() {
-        const { cropX, cropY, cropWidth, cropHeight } = this.state;
-        this.ui.cropSelection.style.left = `${cropX}px`;
-        this.ui.cropSelection.style.top = `${cropY}px`;
-        this.ui.cropSelection.style.width = `${cropWidth}px`;
-        this.ui.cropSelection.style.height = `${cropHeight}px`;
+    calculateDisplayDimensions() {
+        const image = this.ui.originalImage;
+        const viewportWidth = window.innerWidth || document.documentElement.clientWidth || image.width;
+        const viewportHeight = window.innerHeight || document.documentElement.clientHeight || image.height;
+
+        const parse = (value) => Number.parseFloat(value) || 0;
+
+        const content = this.ui.cropModalContent;
+        const header = this.ui.cropHeader;
+        const actions = this.ui.cropActions;
+        const container = this.ui.cropContainer;
+
+        const contentStyles = content ? window.getComputedStyle(content) : null;
+        const paddingX = contentStyles ? parse(contentStyles.paddingLeft) + parse(contentStyles.paddingRight) : 0;
+        const paddingY = contentStyles ? parse(contentStyles.paddingTop) + parse(contentStyles.paddingBottom) : 0;
+
+        const headerStyles = header ? window.getComputedStyle(header) : null;
+        const headerHeight = header ? header.offsetHeight + parse(headerStyles.marginTop) + parse(headerStyles.marginBottom) : 0;
+
+        const actionsStyles = actions ? window.getComputedStyle(actions) : null;
+        const actionsHeight = actions ? actions.offsetHeight + parse(actionsStyles.marginTop) + parse(actionsStyles.marginBottom) : 0;
+
+        const containerStyles = container ? window.getComputedStyle(container) : null;
+        const containerMarginY = containerStyles ? parse(containerStyles.marginTop) + parse(containerStyles.marginBottom) : 0;
+
+        const widthCandidates = [
+            viewportWidth * 0.9 - paddingX,
+            (content ? content.clientWidth : viewportWidth) - paddingX,
+            viewportWidth - 80
+        ].filter((value) => Number.isFinite(value) && value > 0);
+
+        const computedMaxWidth = widthCandidates.length ? Math.min(...widthCandidates) : image.width;
+        const maxWidth = Math.max(160, Math.min(computedMaxWidth, viewportWidth - 40));
+
+        const heightCandidates = [
+            viewportHeight * 0.9 - paddingY - headerHeight - actionsHeight - containerMarginY,
+            viewportHeight - (headerHeight + actionsHeight + containerMarginY + 120),
+            viewportHeight * 0.85
+        ].filter((value) => Number.isFinite(value) && value > 0);
+
+        const computedMaxHeight = heightCandidates.length ? Math.min(...heightCandidates) : image.height;
+        const maxHeight = Math.max(160, Math.min(computedMaxHeight, viewportHeight - 120));
+
+        const scale = Math.min(maxWidth / image.width, maxHeight / image.height, 1);
+
+        const width = Math.max(1, Math.round(image.width * scale));
+        const height = Math.max(1, Math.round(image.height * scale));
+
+        return { width, height };
+    }
+
+    getDefaultSelection(anchor = null) {
+        const { width, height } = this.state.display;
+        if (!width || !height) {
+            return { x: 0, y: 0, width: 1, height: 1 };
+        }
+
+        const targetSize = Math.min(width, height) * 0.8;
+        const normWidth = Math.min(1, targetSize / width);
+        const normHeight = Math.min(1, targetSize / height);
+
+        let x = anchor ? anchor.x - normWidth / 2 : (1 - normWidth) / 2;
+        let y = anchor ? anchor.y - normHeight / 2 : (1 - normHeight) / 2;
+
+        x = this.clampValue(x, 0, 1 - normWidth);
+        y = this.clampValue(y, 0, 1 - normHeight);
+
+        const selection = { x, y, width: normWidth, height: normHeight };
+        this.clampSelection(selection);
+        return selection;
+    }
+
+    getMinSelectionNormalized() {
+        const { width, height } = this.state.display;
+        if (!width || !height) {
+            return { width: 0, height: 0 };
+        }
+
+        const minWidth = Math.min(1, this.MIN_SELECTION_PX / width);
+        const minHeight = Math.min(1, this.MIN_SELECTION_PX / height);
+        return { width: minWidth, height: minHeight };
+    }
+
+    applySelection() {
+        const selection = this.state.selection;
+        const { width, height } = this.state.display;
+        if (!selection || !width || !height) {
+            return;
+        }
+
+        this.clampSelection(selection);
+
+        const left = selection.x * width;
+        const top = selection.y * height;
+        const selectionWidth = selection.width * width;
+        const selectionHeight = selection.height * height;
+
+        const selectionEl = this.ui.cropSelection;
+        selectionEl.style.left = `${left}px`;
+        selectionEl.style.top = `${top}px`;
+        selectionEl.style.width = `${selectionWidth}px`;
+        selectionEl.style.height = `${selectionHeight}px`;
+    }
+
+    clampSelection(selection) {
+        const { width, height } = this.state.display;
+        if (!width || !height || !selection) {
+            return;
+        }
+
+        const min = this.getMinSelectionNormalized();
+        selection.width = this.clampValue(selection.width, min.width, 1);
+        selection.height = this.clampValue(selection.height, min.height, 1);
+        selection.x = this.clampValue(selection.x, 0, 1 - selection.width);
+        selection.y = this.clampValue(selection.y, 0, 1 - selection.height);
+    }
+
+    clampValue(value, min, max) {
+        if (Number.isNaN(value)) return min;
+        if (value < min) return min;
+        if (value > max) return max;
+        return value;
+    }
+
+    getPointerPosition(event) {
+        const rect = this.ui.cropOverlay.getBoundingClientRect();
+        const x = event.clientX - rect.left;
+        const y = event.clientY - rect.top;
+        return {
+            x: this.clampValue(x, 0, rect.width),
+            y: this.clampValue(y, 0, rect.height)
+        };
+    }
+
+    toNormalized(position) {
+        const { width, height } = this.state.display;
+        if (!width || !height) {
+            return { x: 0, y: 0 };
+        }
+        return {
+            x: position.x / width,
+            y: position.y / height
+        };
+    }
+
+    getSelectionPixels() {
+        const selection = this.state.selection;
+        const { width, height } = this.state.display;
+        if (!selection || !width || !height) {
+            return { x: 0, y: 0, width: 0, height: 0 };
+        }
+
+        return {
+            x: selection.x * width,
+            y: selection.y * height,
+            width: selection.width * width,
+            height: selection.height * height
+        };
+    }
+
+    getHandleAtPosition(pointer) {
+        const selection = this.getSelectionPixels();
+        if (selection.width === 0 || selection.height === 0) {
+            return null;
+        }
+
+        const tolerance = 18;
+        const left = selection.x;
+        const right = selection.x + selection.width;
+        const top = selection.y;
+        const bottom = selection.y + selection.height;
+        const centerX = left + selection.width / 2;
+        const centerY = top + selection.height / 2;
+
+        const nearLeft = Math.abs(pointer.x - left) <= tolerance;
+        const nearRight = Math.abs(pointer.x - right) <= tolerance;
+        const nearTop = Math.abs(pointer.y - top) <= tolerance;
+        const nearBottom = Math.abs(pointer.y - bottom) <= tolerance;
+
+        if (nearLeft && nearTop) return 'nw';
+        if (nearRight && nearTop) return 'ne';
+        if (nearLeft && nearBottom) return 'sw';
+        if (nearRight && nearBottom) return 'se';
+
+        if (nearTop && pointer.x >= left && pointer.x <= right) return 'n';
+        if (nearBottom && pointer.x >= left && pointer.x <= right) return 's';
+        if (nearLeft && pointer.y >= top && pointer.y <= bottom) return 'w';
+        if (nearRight && pointer.y >= top && pointer.y <= bottom) return 'e';
+
+        const handleSize = 20;
+        const insideHandle = (cx, cy) =>
+            Math.abs(pointer.x - cx) <= handleSize && Math.abs(pointer.y - cy) <= handleSize;
+
+        if (insideHandle(centerX, top)) return 'n';
+        if (insideHandle(centerX, bottom)) return 's';
+        if (insideHandle(left, centerY)) return 'w';
+        if (insideHandle(right, centerY)) return 'e';
+
+        return null;
+    }
+
+    isInsideSelection(pointer) {
+        const selection = this.getSelectionPixels();
+        if (selection.width === 0 || selection.height === 0) {
+            return false;
+        }
+
+        return pointer.x >= selection.x && pointer.x <= selection.x + selection.width &&
+            pointer.y >= selection.y && pointer.y <= selection.y + selection.height;
+    }
+
+    onPointerDown(event) {
+        if (event.button !== undefined && event.button !== 0) {
+            return;
+        }
+
+        event.preventDefault();
+
+        const pointer = this.getPointerPosition(event);
+        const pointerNorm = this.toNormalized(pointer);
+
+        this.state.startPointer = pointer;
+        this.state.startPointerNorm = pointerNorm;
+        this.state.initialSelection = this.state.selection ? { ...this.state.selection } : null;
+        this.state.activePointerId = event.pointerId;
+
+        const handle = this.getHandleAtPosition(pointer);
+        if (handle) {
+            this.state.mode = 'resize';
+            this.state.activeHandle = handle;
+        } else if (this.isInsideSelection(pointer)) {
+            this.state.mode = 'move';
+            this.state.activeHandle = null;
+        } else {
+            this.state.mode = 'new';
+            this.state.activeHandle = null;
+            this.state.selection = {
+                x: pointerNorm.x,
+                y: pointerNorm.y,
+                width: 0,
+                height: 0
+            };
+        }
+
+        if (typeof this.ui.cropOverlay.setPointerCapture === 'function') {
+            try {
+                this.ui.cropOverlay.setPointerCapture(event.pointerId);
+            } catch (error) {
+                // Ignore if pointer capture fails
+            }
+        }
+
+        this.attachGlobalPointerListeners();
+        this.applySelection();
+    }
+
+    onPointerMove(event) {
+        if (!this.state.mode) {
+            return;
+        }
+
+        event.preventDefault();
+
+        const pointer = this.getPointerPosition(event);
+        const pointerNorm = this.toNormalized(pointer);
+
+        switch (this.state.mode) {
+            case 'move':
+                this.handleMove(pointerNorm);
+                break;
+            case 'resize':
+                this.handleResizeDrag(pointerNorm);
+                break;
+            case 'new':
+                this.handleNewSelection(pointerNorm);
+                break;
+        }
+
+        this.applySelection();
+    }
+
+    handleMove(pointerNorm) {
+        if (!this.state.initialSelection || !this.state.startPointerNorm) {
+            return;
+        }
+
+        const deltaX = pointerNorm.x - this.state.startPointerNorm.x;
+        const deltaY = pointerNorm.y - this.state.startPointerNorm.y;
+
+        this.state.selection = {
+            x: this.state.initialSelection.x + deltaX,
+            y: this.state.initialSelection.y + deltaY,
+            width: this.state.initialSelection.width,
+            height: this.state.initialSelection.height
+        };
+    }
+
+    handleResizeDrag(pointerNorm) {
+        if (!this.state.initialSelection) {
+            return;
+        }
+
+        const initial = this.state.initialSelection;
+        const min = this.getMinSelectionNormalized();
+        const startRight = initial.x + initial.width;
+        const startBottom = initial.y + initial.height;
+
+        let selection = { ...initial };
+
+        const clamp = (value, minValue, maxValue) => this.clampValue(value, minValue, maxValue);
+
+        switch (this.state.activeHandle) {
+            case 'nw': {
+                const newX = clamp(pointerNorm.x, 0, startRight - min.width);
+                const newY = clamp(pointerNorm.y, 0, startBottom - min.height);
+                selection.x = newX;
+                selection.y = newY;
+                selection.width = startRight - newX;
+                selection.height = startBottom - newY;
+                break;
+            }
+            case 'ne': {
+                const newRight = clamp(pointerNorm.x, initial.x + min.width, 1);
+                const newY = clamp(pointerNorm.y, 0, startBottom - min.height);
+                selection.width = newRight - initial.x;
+                selection.y = newY;
+                selection.height = startBottom - newY;
+                break;
+            }
+            case 'sw': {
+                const newX = clamp(pointerNorm.x, 0, startRight - min.width);
+                const newBottom = clamp(pointerNorm.y, initial.y + min.height, 1);
+                selection.x = newX;
+                selection.width = startRight - newX;
+                selection.height = newBottom - initial.y;
+                break;
+            }
+            case 'se': {
+                const newRight = clamp(pointerNorm.x, initial.x + min.width, 1);
+                const newBottom = clamp(pointerNorm.y, initial.y + min.height, 1);
+                selection.width = newRight - initial.x;
+                selection.height = newBottom - initial.y;
+                break;
+            }
+            case 'n': {
+                const newY = clamp(pointerNorm.y, 0, startBottom - min.height);
+                selection.y = newY;
+                selection.height = startBottom - newY;
+                break;
+            }
+            case 's': {
+                const newBottom = clamp(pointerNorm.y, initial.y + min.height, 1);
+                selection.height = newBottom - initial.y;
+                break;
+            }
+            case 'w': {
+                const newX = clamp(pointerNorm.x, 0, startRight - min.width);
+                selection.x = newX;
+                selection.width = startRight - newX;
+                break;
+            }
+            case 'e': {
+                const newRight = clamp(pointerNorm.x, initial.x + min.width, 1);
+                selection.width = newRight - initial.x;
+                break;
+            }
+            default:
+                break;
+        }
+
+        this.state.selection = selection;
+    }
+
+    handleNewSelection(pointerNorm) {
+        if (!this.state.startPointerNorm) {
+            return;
+        }
+
+        const start = this.state.startPointerNorm;
+        const min = this.getMinSelectionNormalized();
+
+        let x = Math.min(start.x, pointerNorm.x);
+        let y = Math.min(start.y, pointerNorm.y);
+        let width = Math.abs(pointerNorm.x - start.x);
+        let height = Math.abs(pointerNorm.y - start.y);
+
+        if (width < min.width) {
+            width = min.width;
+            if (pointerNorm.x < start.x) {
+                x = start.x - width;
+            }
+        }
+
+        if (height < min.height) {
+            height = min.height;
+            if (pointerNorm.y < start.y) {
+                y = start.y - height;
+            }
+        }
+
+        this.state.selection = { x, y, width, height };
+    }
+
+    onPointerUp(event) {
+        if (!this.state.mode) {
+            return;
+        }
+
+        if (event) {
+            try {
+                if (typeof this.ui.cropOverlay.releasePointerCapture === 'function' &&
+                    this.ui.cropOverlay.hasPointerCapture &&
+                    this.ui.cropOverlay.hasPointerCapture(event.pointerId)) {
+                    this.ui.cropOverlay.releasePointerCapture(event.pointerId);
+                }
+            } catch (error) {
+                // Ignore release errors
+            }
+        }
+
+        this.applySelection();
+        this.resetPointerState();
+    }
+
+    resetPointerState() {
+        this.state.mode = null;
+        this.state.activeHandle = null;
+        this.state.startPointer = null;
+        this.state.startPointerNorm = null;
+        this.state.initialSelection = null;
+        this.state.activePointerId = null;
+        this.detachGlobalPointerListeners();
+    }
+
+    attachGlobalPointerListeners() {
+        if (this.globalPointerListenersAttached) {
+            return;
+        }
+        window.addEventListener('pointerup', this.boundPointerUp);
+        window.addEventListener('pointercancel', this.boundPointerUp);
+        this.globalPointerListenersAttached = true;
+    }
+
+    detachGlobalPointerListeners() {
+        if (!this.globalPointerListenersAttached) {
+            return;
+        }
+        window.removeEventListener('pointerup', this.boundPointerUp);
+        window.removeEventListener('pointercancel', this.boundPointerUp);
+        this.globalPointerListenersAttached = false;
+    }
+
+    handleResize() {
+        if (this.ui.cropModal.classList.contains('hidden') || !this.ui.originalImage) {
+            return;
+        }
+
+        if (this.resizeFrame) {
+            cancelAnimationFrame(this.resizeFrame);
+        }
+
+        this.resizeFrame = requestAnimationFrame(() => {
+            this.resizeFrame = null;
+            this.layoutCropSurface({ resetSelection: false });
+        });
+    }
+
+    detachResizeListener() {
+        if (this.resizeFrame) {
+            cancelAnimationFrame(this.resizeFrame);
+            this.resizeFrame = null;
+        }
+        window.removeEventListener('resize', this.boundHandleResize);
     }
 
     confirmCrop() {
-        if (!this.ui.originalImage) return;
+        if (!this.ui.originalImage || !this.state.selection) return;
+
+        this.detachResizeListener();
+        this.resetPointerState();
 
         const tempCanvas = document.createElement('canvas');
         const tempCtx = tempCanvas.getContext('2d');
 
-        const scale = 1 / this.state.canvasScale;
-        const actualX = this.state.cropX * scale;
-        const actualY = this.state.cropY * scale;
-        const actualWidth = this.state.cropWidth * scale;
-        const actualHeight = this.state.cropHeight * scale;
+        const { selection } = this.state;
+        const sourceX = selection.x * this.ui.originalImage.width;
+        const sourceY = selection.y * this.ui.originalImage.height;
+        const sourceWidth = selection.width * this.ui.originalImage.width;
+        const sourceHeight = selection.height * this.ui.originalImage.height;
 
-        const size = Math.min(actualWidth, actualHeight);
+        const size = Math.min(sourceWidth, sourceHeight);
         tempCanvas.width = 400;
         tempCanvas.height = 400;
 
         tempCtx.drawImage(
             this.ui.originalImage,
-            actualX, actualY, size, size,
+            sourceX, sourceY, size, size,
             0, 0, 400, 400
         );
 
@@ -144,216 +609,7 @@ export class CropManager {
         this.ui.imageInput.value = '';
         this.ui.isSelectingFile = false;
         this.ui.clearShuffleTimer();
-    }
-
-    onCropMouseDown(e) {
-        e.preventDefault();
-        const rect = this.ui.cropOverlay.getBoundingClientRect();
-        const x = e.clientX - rect.left;
-        const y = e.clientY - rect.top;
-
-        this.state.startX = x;
-        this.state.startY = y;
-        this.state.startCropX = this.state.cropX;
-        this.state.startCropY = this.state.cropY;
-        this.state.startCropWidth = this.state.cropWidth;
-        this.state.startCropHeight = this.state.cropHeight;
-
-        const handle = this.getHandleAtPosition(x, y);
-        if (handle) {
-            this.state.isResizing = true;
-            this.state.dragHandle = handle;
-        } else if (this.isInsideCropArea(x, y)) {
-            this.state.isDragging = true;
-        } else {
-            this.state.cropX = x;
-            this.state.cropY = y;
-            this.state.cropWidth = 0;
-            this.state.cropHeight = 0;
-            this.state.isDragging = true;
-            this.updateCropSelection();
-        }
-    }
-
-    onCropMouseMove(e) {
-        if (!this.state.isDragging && !this.state.isResizing) return;
-
-        const rect = this.ui.cropOverlay.getBoundingClientRect();
-        const x = e.clientX - rect.left;
-        const y = e.clientY - rect.top;
-
-        const deltaX = x - this.state.startX;
-        const deltaY = y - this.state.startY;
-
-        if (this.state.isDragging && !this.state.isResizing) {
-            this.state.cropX = Math.max(0, Math.min(
-                this.ui.cropCanvas.width - this.state.cropWidth,
-                this.state.startCropX + deltaX
-            ));
-            this.state.cropY = Math.max(0, Math.min(
-                this.ui.cropCanvas.height - this.state.cropHeight,
-                this.state.startCropY + deltaY
-            ));
-        } else if (this.state.isResizing) {
-            this.resizeCropSelection(deltaX, deltaY);
-        }
-
-        this.updateCropSelection();
-    }
-
-    onCropMouseUp() {
-        this.state.isDragging = false;
-        this.state.isResizing = false;
-        this.state.dragHandle = null;
-    }
-
-    getHandleAtPosition(x, y, customTolerance = null) {
-        const { cropX, cropY, cropWidth, cropHeight } = this.state;
-        const tolerance = customTolerance || 15;
-
-        const handles = {
-            'nw': { x: cropX, y: cropY },
-            'ne': { x: cropX + cropWidth, y: cropY },
-            'sw': { x: cropX, y: cropY + cropHeight },
-            'se': { x: cropX + cropWidth, y: cropY + cropHeight },
-            'n': { x: cropX + cropWidth / 2, y: cropY },
-            's': { x: cropX + cropWidth / 2, y: cropY + cropHeight },
-            'w': { x: cropX, y: cropY + cropHeight / 2 },
-            'e': { x: cropX + cropWidth, y: cropY + cropHeight / 2 }
-        };
-
-        for (const [handle, pos] of Object.entries(handles)) {
-            if (Math.abs(x - pos.x) < tolerance && Math.abs(y - pos.y) < tolerance) {
-                return handle;
-            }
-        }
-
-        return null;
-    }
-
-    isInsideCropArea(x, y) {
-        const { cropX, cropY, cropWidth, cropHeight } = this.state;
-        return x >= cropX && x <= cropX + cropWidth &&
-               y >= cropY && y <= cropY + cropHeight;
-    }
-
-    resizeCropSelection(deltaX, deltaY) {
-        const handle = this.state.dragHandle;
-        const { startCropX, startCropY, startCropWidth, startCropHeight } = this.state;
-        const minSize = 50;
-
-        switch (handle) {
-            case 'nw':
-                this.state.cropX = Math.max(0, startCropX + deltaX);
-                this.state.cropY = Math.max(0, startCropY + deltaY);
-                this.state.cropWidth = Math.max(minSize, startCropWidth - deltaX);
-                this.state.cropHeight = Math.max(minSize, startCropHeight - deltaY);
-                break;
-            case 'ne':
-                this.state.cropY = Math.max(0, startCropY + deltaY);
-                this.state.cropWidth = Math.max(minSize, startCropWidth + deltaX);
-                this.state.cropHeight = Math.max(minSize, startCropHeight - deltaY);
-                break;
-            case 'sw':
-                this.state.cropX = Math.max(0, startCropX + deltaX);
-                this.state.cropWidth = Math.max(minSize, startCropWidth - deltaX);
-                this.state.cropHeight = Math.max(minSize, startCropHeight + deltaY);
-                break;
-            case 'se':
-                this.state.cropWidth = Math.max(minSize, startCropWidth + deltaX);
-                this.state.cropHeight = Math.max(minSize, startCropHeight + deltaY);
-                break;
-            case 'n':
-                this.state.cropY = Math.max(0, startCropY + deltaY);
-                this.state.cropHeight = Math.max(minSize, startCropHeight - deltaY);
-                break;
-            case 's':
-                this.state.cropHeight = Math.max(minSize, startCropHeight + deltaY);
-                break;
-            case 'w':
-                this.state.cropX = Math.max(0, startCropX + deltaX);
-                this.state.cropWidth = Math.max(minSize, startCropWidth - deltaX);
-                break;
-            case 'e':
-                this.state.cropWidth = Math.max(minSize, startCropWidth + deltaX);
-                break;
-        }
-
-        this.state.cropX = Math.max(0, Math.min(
-            this.ui.cropCanvas.width - this.state.cropWidth, this.state.cropX
-        ));
-        this.state.cropY = Math.max(0, Math.min(
-            this.ui.cropCanvas.height - this.state.cropHeight, this.state.cropY
-        ));
-        this.state.cropWidth = Math.min(
-            this.ui.cropCanvas.width - this.state.cropX, this.state.cropWidth
-        );
-        this.state.cropHeight = Math.min(
-            this.ui.cropCanvas.height - this.state.cropY, this.state.cropHeight
-        );
-    }
-
-    onCropTouchStart(e) {
-        e.preventDefault();
-        const touch = e.touches[0];
-        const rect = this.ui.cropOverlay.getBoundingClientRect();
-        const x = touch.clientX - rect.left;
-        const y = touch.clientY - rect.top;
-
-        this.state.startX = x;
-        this.state.startY = y;
-        this.state.startCropX = this.state.cropX;
-        this.state.startCropY = this.state.cropY;
-        this.state.startCropWidth = this.state.cropWidth;
-        this.state.startCropHeight = this.state.cropHeight;
-
-        const handle = this.getHandleAtPosition(x, y, 25);
-        if (handle) {
-            this.state.isResizing = true;
-            this.state.dragHandle = handle;
-        } else if (this.isInsideCropArea(x, y)) {
-            this.state.isDragging = true;
-        } else {
-            this.state.cropX = x;
-            this.state.cropY = y;
-            this.state.cropWidth = 0;
-            this.state.cropHeight = 0;
-            this.state.isDragging = true;
-            this.updateCropSelection();
-        }
-    }
-
-    onCropTouchMove(e) {
-        e.preventDefault();
-        if (!this.state.isDragging && !this.state.isResizing) return;
-
-        const touch = e.touches[0];
-        const rect = this.ui.cropOverlay.getBoundingClientRect();
-        const x = touch.clientX - rect.left;
-        const y = touch.clientY - rect.top;
-
-        const deltaX = x - this.state.startX;
-        const deltaY = y - this.state.startY;
-
-        if (this.state.isDragging && !this.state.isResizing) {
-            this.state.cropX = Math.max(0, Math.min(
-                this.ui.cropCanvas.width - this.state.cropWidth,
-                this.state.startCropX + deltaX
-            ));
-            this.state.cropY = Math.max(0, Math.min(
-                this.ui.cropCanvas.height - this.state.cropHeight,
-                this.state.startCropY + deltaY
-            ));
-        } else if (this.state.isResizing) {
-            this.resizeCropSelection(deltaX, deltaY);
-        }
-
-        this.updateCropSelection();
-    }
-
-    onCropTouchEnd() {
-        this.state.isDragging = false;
-        this.state.isResizing = false;
-        this.state.dragHandle = null;
+        this.detachResizeListener();
+        this.resetPointerState();
     }
 }

--- a/style.css
+++ b/style.css
@@ -462,17 +462,18 @@ body {
 
 .crop-container {
     position: relative;
-    display: inline-block;
-    margin-bottom: 25px;
+    display: block;
+    margin: 0 auto 25px;
     border-radius: 15px;
     overflow: hidden;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+    max-width: 100%;
 }
 
 .crop-canvas {
     display: block;
-    max-width: 600px;
-    max-height: 400px;
+    max-width: none;
+    max-height: none;
 }
 
 .crop-overlay {
@@ -483,6 +484,7 @@ body {
     height: 100%;
     background: rgba(0, 0, 0, 0.5);
     cursor: crosshair;
+    touch-action: none;
 }
 
 .crop-selection {
@@ -566,12 +568,6 @@ body {
         padding: 20px;
         margin: 20px;
     }
-    
-    .crop-canvas {
-        max-width: 100%;
-        max-height: 300px;
-    }
-    
     .crop-header h2 {
         font-size: 1.5rem;
     }
@@ -872,6 +868,43 @@ body {
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
     border: 3px solid #667eea;
     animation: shufflePreviewPulse 2s infinite;
+}
+
+.shuffle-settings {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    margin: 10px 0 25px;
+    padding: 18px 24px;
+    background: linear-gradient(135deg, rgba(102, 126, 234, 0.12), rgba(118, 75, 162, 0.1));
+    border-radius: 18px;
+    border: 1px solid rgba(102, 126, 234, 0.2);
+    box-shadow: 0 14px 36px rgba(102, 126, 234, 0.18);
+}
+
+.shuffle-label {
+    font-weight: 600;
+    color: #6c757d;
+    text-align: center;
+    letter-spacing: 0.3px;
+}
+
+.shuffle-settings .difficulty-select {
+    width: 100%;
+    max-width: 240px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(237, 242, 255, 0.96));
+    border: 2px solid rgba(102, 126, 234, 0.3);
+    box-shadow: 0 12px 30px rgba(102, 126, 234, 0.22);
+    transition: all 0.3s ease;
+}
+
+.shuffle-settings .difficulty-select:hover,
+.shuffle-settings .difficulty-select:focus {
+    background: white;
+    border-color: #7f9cf5;
+    box-shadow: 0 16px 36px rgba(102, 126, 234, 0.28);
+    outline: none;
 }
 
 @keyframes shufflePreviewPulse {


### PR DESCRIPTION
## Summary
- rebuild the crop manager around viewport-aware canvas sizing with normalized selections and pointer-based dragging and resizing
- update the UI to target pointer events and the new crop elements while softening the crop container styling for centered responsive layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca28385974832fb833ece9e5a9834f